### PR TITLE
Plus de souplesse dans les dés explosifs

### DIFF
--- a/cof2e.html
+++ b/cof2e.html
@@ -11051,7 +11051,7 @@ on("clicked:repeating_armes:attack-btn", function(eventInfo) {
       modifiers.push("explodemax");
 
     let dmOpt = "";
-    if (modifiers.includes("explodemax") && !dm.endsWith("!"))
+    if (modifiers.includes("explodemax") && !dm.includes("!"))
       dmOpt += "!";
     if (modifiers.includes("reroll1"))
       dmOpt += "r";
@@ -14276,7 +14276,7 @@ on("clicked:repeating_npcarmes:npcatk-btn", function() {
       modifiers.push("explodemax");
 
     let dmOpt = "";
-    if (modifiers.includes("explodemax") && !dm.endsWith("!"))
+    if (modifiers.includes("explodemax") && !dm.includes("!"))
       dmOpt += "!";
     if (modifiers.includes("reroll1"))
       dmOpt += "r";


### PR DESCRIPTION
En low fantasy, un des mes joueurs à une arme enchantée (d6) qui explose sur 6, et qui transforme aussi les 1 en 6 (explosifs).

Du coup j'avais besoin d'un jet de DM un peu particulier sur roll20 (on peut pas le faire exactement, mais `1d7r1!>6` ça s'en approche).
Sauf que vu que je suis en low fantasy, le rajout du `!` automatique en fin de jet de DM casse le jet (qui est transformé en `1d7r1!>6!`).

J'ai donc changé le check pour qu'on ne rajoute pas de "!" si le jet contient déjà un "!", plutôt que de check seulement la fin du dé. (La logique c'est que si un joueur met déjà un "!" dans son dé de DM, visiblement il sait ce qu'il fait donc il pourra se débrouiller sans trop d'automatisation).

Je te laisse voir si tu trouves ça intéressant à merge ou non :)